### PR TITLE
fix: ensure ASCII title renders on Android

### DIFF
--- a/css/terminal.css
+++ b/css/terminal.css
@@ -5,7 +5,7 @@
     --terminal-highlight: #6eff6e;
     --terminal-dim: #2a7a2a;
     --terminal-accent: #40c940;
-    --terminal-font: 'Share Tech Mono', 'Consolas', 'Monaco', 'Courier New', monospace;
+    --terminal-font: 'Share Tech Mono', 'Noto Sans Mono', 'Consolas', 'Monaco', 'Courier New', monospace;
     --border-char: '═';
 }
 

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <link rel="alternate icon" href="favicon.ico">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=Noto+Sans+Mono&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/reset.css">
     <link rel="stylesheet" href="css/terminal.css">
     <link rel="stylesheet" href="css/animations.css">

--- a/js/modules/ascii-art.js
+++ b/js/modules/ascii-art.js
@@ -20,7 +20,6 @@ export function initASCIITitle() {
     pre.className = 'ascii-title-text';
     pre.style.margin = '0';
     pre.style.padding = '0';
-    pre.style.fontFamily = 'Consolas, "Courier New", monospace';
     pre.style.lineHeight = '1';
     
     // Join lines with newlines, keeping original spaces


### PR DESCRIPTION
## Summary
- load Noto Sans Mono to support block-character ASCII art across devices
- use updated font stack globally and remove hardcoded font family from ASCII title

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `npm run lint` *(fails: ENOENT package.json)*
- `npm run build` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad74a4fbc0833383d0c240d6daf6ec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved typography by adding Noto Sans Mono to the terminal font stack for clearer, more consistent monospace rendering across platforms.
  * Updated the site to load the new font via Google Fonts.
  * ASCII art title now inherits the global terminal font for a cohesive look.

* **Refactor**
  * Removed hardcoded font assignment in the ASCII art module to rely on centralized CSS font settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->